### PR TITLE
chore: support legacy and overloaded events

### DIFF
--- a/abis/Alchemist.json
+++ b/abis/Alchemist.json
@@ -1,4 +1,46 @@
 [
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "Liquidate",
+    "inputs": [
+      { "type": "address", "name": "owner", "indexed": true },
+      { "type": "address", "name": "yieldToken", "indexed": true },
+      { "type": "uint256", "name": "shares" }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "Repay",
+    "inputs": [
+      { "type": "address", "name": "sender", "indexed": true },
+      { "type": "address", "name": "underlyingToken", "indexed": true },
+      { "type": "uint256", "name": "amount" },
+      { "type": "address", "name": "recipient" }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "Liquidate",
+    "inputs": [
+      { "type": "address", "name": "owner", "indexed": true },
+      { "type": "address", "name": "yieldToken", "indexed": true },
+      { "type": "address", "name": "underlyingToken", "indexed": true },
+      { "type": "uint256", "name": "shares" }
+    ]
+  },
+  {
+    "type": "event",
+    "anonymous": false,
+    "name": "Harvest",
+    "inputs": [
+      { "type": "address", "name": "yieldToken", "indexed": true },
+      { "type": "uint256", "name": "minimumAmountOut" },
+      { "type": "uint256", "name": "totalHarvested" }
+    ]
+  },
   { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
   {
     "anonymous": false,

--- a/scripts/commands/generate-abis.ts
+++ b/scripts/commands/generate-abis.ts
@@ -16,6 +16,16 @@ export interface ProcessedArtifact {
 export const command = 'generate-abis';
 export const description = 'Extracts & clean abis from the deployment output';
 
+// NOTE: These are partial legacy contract interfaces that have been deprecated but still need to be considered for historical blocks.
+const legacy: Record<string, utils.Interface> = {
+  Alchemist: new utils.Interface([
+    `event Liquidate(address indexed owner, address indexed yieldToken, uint256 shares)`,
+    `event Repay(address indexed sender, address indexed underlyingToken, uint256 amount, address recipient)`,
+    `event Liquidate(address indexed owner, address indexed yieldToken, address indexed underlyingToken, uint256 shares)`,
+    `event Harvest(address indexed yieldToken, uint256 minimumAmountOut, uint256 totalHarvested)`,
+  ]),
+};
+
 async function getAbis() {
   const artifacts = {
     Alchemist: path.resolve(packageRoot, 'v2-contracts/deployments/mainnet/AlchemistV2_alETH.json'),
@@ -25,7 +35,12 @@ async function getAbis() {
 
   const contents = await Promise.all(
     Object.entries(artifacts).map<Promise<ProcessedArtifact>>(async ([contractName, sourcePath]) => {
-      const rawJson = (await fs.readJson(sourcePath)).abi as JsonFragment[];
+      // NOTE: We put the legacy abis before the current abis to incrementally add numerical suffixes over time. Otherwise, every change
+      // in a event or call signature would require a refactor to existing code.
+      const legacyAbi = JSON.parse((legacy[contractName]?.format(utils.FormatTypes.json) as string) ?? '[]');
+      const currentAbi = (await fs.readJson(sourcePath)).abi as JsonFragment[];
+      const rawJson = [...legacyAbi, ...currentAbi];
+
       const destinationPath = path.resolve(packageRoot, 'abis', `${contractName}.json`);
       const contractInterface = new utils.Interface(rawJson);
 

--- a/sources/Alchemist.ts
+++ b/sources/Alchemist.ts
@@ -1,5 +1,5 @@
 import { utils } from 'ethers';
-import { eventDeclaration, deploymentAddress } from './utils/abis';
+import { eventDeclarations, deploymentAddress } from './utils/abis';
 import { networkName, startBlockNumber } from './utils/constants';
 import { DataSource } from './utils/types';
 
@@ -21,7 +21,7 @@ export function createAlchemist(
       language: 'wasm/assemblyscript',
       file: 'subgraph/handlers/Alchemist.ts',
       entities: [],
-      eventHandlers: AlchemistEvents.map((fragment) => eventDeclaration(fragment)),
+      eventHandlers: eventDeclarations(AlchemistEvents),
       abis: [
         {
           name: 'Alchemist',

--- a/sources/FactoryPool.ts
+++ b/sources/FactoryPool.ts
@@ -1,5 +1,5 @@
 import { utils } from 'ethers';
-import { eventDeclaration, deploymentAddress } from './utils/abis';
+import { eventDeclarations } from './utils/abis';
 import { networkName } from './utils/constants';
 import { DataSource } from './utils/types';
 
@@ -17,7 +17,7 @@ export function createFactoryPool(name: string, block: number, address: string):
       language: 'wasm/assemblyscript',
       file: 'subgraph/handlers/FactoryPool.ts',
       entities: [],
-      eventHandlers: FactoryPoolEvents.map((fragment) => eventDeclaration(fragment)),
+      eventHandlers: eventDeclarations(FactoryPoolEvents),
       abis: [
         {
           name: 'FactoryPool',

--- a/sources/MetaPool.ts
+++ b/sources/MetaPool.ts
@@ -1,5 +1,5 @@
 import { utils } from 'ethers';
-import { eventDeclaration, deploymentAddress } from './utils/abis';
+import { eventDeclarations } from './utils/abis';
 import { networkName } from './utils/constants';
 import { DataSource } from './utils/types';
 
@@ -17,7 +17,7 @@ export function createMetaPool(name: string, block: number, address: string): Da
       language: 'wasm/assemblyscript',
       file: 'subgraph/handlers/MetaPool.ts',
       entities: [],
-      eventHandlers: MetaPoolEvents.map((fragment) => eventDeclaration(fragment)),
+      eventHandlers: eventDeclarations(MetaPoolEvents),
       abis: [
         {
           name: 'MetaPool',

--- a/sources/Transmuter.ts
+++ b/sources/Transmuter.ts
@@ -1,5 +1,5 @@
 import { utils } from 'ethers';
-import { eventDeclaration, deploymentAddress } from './utils/abis';
+import { eventDeclarations, deploymentAddress } from './utils/abis';
 import { networkName, startBlockNumber } from './utils/constants';
 import { DataSource } from './utils/types';
 
@@ -21,7 +21,7 @@ export function createTransmuter(
       language: 'wasm/assemblyscript',
       file: 'subgraph/handlers/Transmuter.ts',
       entities: [],
-      eventHandlers: TransmuterEvents.map((fragment) => eventDeclaration(fragment)),
+      eventHandlers: eventDeclarations(TransmuterEvents),
       abis: [
         {
           name: 'Transmuter',

--- a/sources/TransmuterBuffer.ts
+++ b/sources/TransmuterBuffer.ts
@@ -1,5 +1,5 @@
 import { utils } from 'ethers';
-import { eventDeclaration, deploymentAddress } from './utils/abis';
+import { eventDeclarations, deploymentAddress } from './utils/abis';
 import { networkName, startBlockNumber } from './utils/constants';
 import { DataSource } from './utils/types';
 
@@ -21,7 +21,7 @@ export function createTransmuterBuffer(
       language: 'wasm/assemblyscript',
       file: 'subgraph/handlers/TransmuterBuffer.ts',
       entities: [],
-      eventHandlers: TransmuterBufferEvents.map((fragment) => eventDeclaration(fragment)),
+      eventHandlers: eventDeclarations(TransmuterBufferEvents),
       abis: [
         {
           name: 'TransmuterBuffer',

--- a/sources/utils/abis.ts
+++ b/sources/utils/abis.ts
@@ -1,16 +1,40 @@
 import { utils } from 'ethers';
 import { JsonFragment } from '@ethersproject/abi';
 
+type Event = utils.EventFragment | JsonFragment | string;
+
 function formatParams(params: utils.ParamType[]) {
   return params.map((param) => `${param.indexed ? 'indexed ' : ''}${param.type}`).join(',');
 }
 
-export function eventDeclaration(input: utils.EventFragment | JsonFragment | string) {
+function eventHandler(name: string, reserved: string[] = []) {
+  let handler = name;
+  let suffix = 0;
+
+  while (reserved.includes(handler)) {
+    handler = `${name}${++suffix}`;
+  }
+
+  return handler;
+}
+
+function eventDeclaration(input: Event, reserved: string[] = []) {
   const fragment = utils.EventFragment.from(input);
-  const handler = `handle${fragment.name}`;
+  const handler = eventHandler(`handle${fragment.name}`, reserved);
   const event = `${fragment.name}(${formatParams(fragment.inputs)})`;
 
   return { event, handler };
+}
+
+export function eventDeclarations(input: Event[]) {
+  const reserved: string[] = [];
+
+  return input.reduce<{ event: string; handler: string }[]>((carry, current) => {
+    const item = eventDeclaration(current, reserved);
+    reserved.push(item.handler);
+
+    return carry.concat(item);
+  }, []);
 }
 
 export function deploymentAddress(artifact: string): string {


### PR DESCRIPTION
This makes it so that events with the same name (overloads or from legacy abis) have a numerical suffix (1, 2, 3, etc.) appended to them.

I've added the legacy Alchemist contract first (before the current version), because this means that as you add more signatures, they'll have these suffixes added incrementally. The original version will remain at suffix-free (e.g. `handleHarvest`) vs. subsequent event signature / call signature changes will have numerical suffixes appended (e.g. `handleHarvest1`, etc.). This is imho better because otherwise you have to refactor every time you add a new overload or replace an event signature.

So here, the oldest / first event signature to have existed will be (among the others that I saw were changed):

```ts
function handleHarvest(event: Harvest): void { ... }
```

And e.g. the current active version will be at

```ts
function handleHarvest1(event: Harvest1): void { ... }
```

Please note that you also have to use the right / matching event object (e.g. `Harvest1`, `Harvest2`, etc. ...). If you ever add overloads for view functions the same applies.